### PR TITLE
add possibility to configure the name of the listening network interface

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-IP_ADDRESS=$(ip -4 addr show eth0 | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
+IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
+IP_ADDRESS=${DOCKER_IP_ADDRESS:-${IP_ADDRESS}}
 
 # Ensure the Erlang node name is set correctly
 if env | grep "DOCKER_VERNEMQ_NODENAME" -q; then


### PR DESCRIPTION
Currently the name of the network interface inside of the docker container is hard coded in the `vernemq.sh` script. If you use for example the docker run argument `--net=host` it is possible that the network interface is then called enp0s3 or ens0s3 and not eth0. Which then breaks the current script.

With this fix you can override the default interface name (which is eth0) with a custom one.