### PR TITLE
Debian Dockerfile missing curl and jq

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM debian:stretch-slim
 
 RUN \
     apt-get update \
-    && apt-get -y install openssl iproute2 \
+    && apt-get -y install openssl iproute2 curl jq \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Defaults


### PR DESCRIPTION
curl and jq are used for Kubernetes API queries, such as namespace and pods discovery.

Currently prevents cluster joining as node DNS is not correctly detected (vernemq-stg-0..mqtt.svc.cluster.local) because API calls fail. Correct would be vernemq-stg-0.vernemq-stg.mqtt.svc.cluster.local.

Tested in GKE, this fixes cluster joining.