### PR TITLE
Configurable Kubernetes autodiscovery labelSelector

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 
 # Defaults
-ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
+ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR "app=vernemq"
 ENV DOCKER_VERNEMQ_LOG__CONSOLE console
 
 RUN \
@@ -28,7 +28,7 @@ RUN \
 	&& rm -rf /var/lib/apt/lists/*
 
 # Defaults
-ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
+ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR "app=vernemq"
 ENV DOCKER_VERNEMQ_LOG__CONSOLE console
 ENV PATH "/vernemq/bin:$PATH"
 ADD bin/vernemq.sh /usr/sbin/start_vernemq

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -7,7 +7,7 @@ ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 
 # Defaults
-ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
+ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR "app=vernemq"
 ENV DOCKER_VERNEMQ_LOG__CONSOLE console
 
 RUN \
@@ -26,7 +26,7 @@ RUN \
     && apk add --no-cache ncurses-libs openssl libstdc++ jq curl bash
 
 # Defaults
-ENV DOCKER_VERNEMQ_KUBERNETES_APP_LABEL vernemq
+ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR "app=vernemq"
 ENV DOCKER_VERNEMQ_LOG__CONSOLE console
 ENV PATH "/vernemq/bin:$PATH"
 ADD bin/vernemq.sh /usr/sbin/start_vernemq

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This allows a newly started container to automatically join a VerneMQ cluster. A
 When running VerneMQ inside Kubernetes, it is possible to cause pods matching a specific label to cluster altogether automatically.
 This feature uses Kubernetes' API to discover other peers, and relies on the [default pod service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/) which has to be enabled.
 
-Simply set ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1``` in your pod's environment, and expose your own pod name through ```MY_POD_NAME``` . By default, this setting will cause all pods in the same namespace with the ```app=vernemq``` label to join the same cluster. Cluster name (defaults to `cluster.local`), namespace and label settings can be overridden with ```DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME```, ```DOCKER_VERNEMQ_KUBERNETES_NAMESPACE``` and ```DOCKER_VERNEMQ_KUBERNETES_APP_LABEL``` respectively.
+Simply set ```DOCKER_VERNEMQ_DISCOVERY_KUBERNETES=1``` in your pod's environment, and expose your own pod name through ```MY_POD_NAME``` . By default, this setting will cause all pods in the same namespace with the ```app=vernemq``` label to join the same cluster. Cluster name (defaults to `cluster.local`), namespace and label settings can be overridden with ```DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME```, ```DOCKER_VERNEMQ_KUBERNETES_NAMESPACE``` and ```DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR``` respectively.
 
 An example configuration of your pod's environment looks like this:
 
@@ -48,8 +48,8 @@ An example configuration of your pod's environment looks like this:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
-      - name: DOCKER_VERNEMQ_KUBERNETES_APP_LABEL
-        value: "myverneinstance"
+      - name: DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR
+        value: "app=vernemq,release=myinstance"
 
 When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_NODE```.
 

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -26,7 +26,7 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
     # Let's get the namespace if it isn't set
     DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-`cat /var/run/secrets/kubernetes.io/serviceaccount/namespace`}
     # Let's set our nodename correctly
-    VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
+    VERNEMQ_KUBERNETES_SUBDOMAIN=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')
     if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
     else
@@ -35,7 +35,7 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
 
     sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${VERNEMQ_KUBERNETES_HOSTNAME}/" /vernemq/etc/vm.args
     # Hack into K8S DNS resolution (temporarily)
-    kube_pod_names=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=app=$DOCKER_VERNEMQ_KUBERNETES_APP_LABEL -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
+    kube_pod_names=$(curl -X GET $insecure --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt https://kubernetes.default.svc.$DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME/api/v1/namespaces/$DOCKER_VERNEMQ_KUBERNETES_NAMESPACE/pods?labelSelector=$DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR -H "Authorization: Bearer $(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
     for kube_pod_name in $kube_pod_names;
     do
         if [ $kube_pod_name == "null" ]


### PR DESCRIPTION
This is a fix for #90.

Use $DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR instead of $DOCKER_VERNEMQ_KUBERNETES_APP_LABEL to configure kubernetes autodiscovery