### PR TITLE
Add Docker HEALTHCHECK to Alpine image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -57,5 +57,7 @@ EXPOSE 1883 8883 8080 44053 4369 8888 \
 
 VOLUME ["/vernemq/log", "/vernemq/data", "/vernemq/etc"]
 
+HEALTHCHECK CMD vernemq ping || exit 1
+
 USER vernemq
 CMD ["start_vernemq"]


### PR DESCRIPTION
We forgot to add a HEALTHCHECK to the Alpine image in https://github.com/vernemq/docker-vernemq/pull/13
This PR fixes this.