### PR TITLE
bump Erlang/OTP to v21 which is supported by VMQ as of v1.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM erlang:20.3 AS build-env
+FROM erlang:21 AS build-env
 
 WORKDIR /vernemq-build
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM erlang:20.3-alpine AS build-env
+FROM erlang:21-alpine AS build-env
 
 WORKDIR /vernemq-build
 


### PR DESCRIPTION
Upgrade Erlang/OTP to version 21. This version is supported since VerneMQ v1.6.2 and works fine here, including some Elixir plugin development.
