### PR TITLE
[helm] Enable security context by default in Helm chart

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.7.0
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 0.2.0
+version: 0.3.0
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -41,10 +41,10 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 podAntiAffinity: soft
 
-securityContext: {}
-#  runAsUser: 1000
-#  runAsGroup: 1000
-#  fsGroup: 1000
+securityContext:
+  runAsUser: 10000
+  runAsGroup: 10000
+  fsGroup: 10000
 
 ## If RBAC is enabled on the cluster,VerneMQ needs a service account
 ## with permissisions sufficient to list pods


### PR DESCRIPTION
Because I don't see why it wouldn't be enabled by default and because I systematically enable it myself.