### PR TITLE
bump VerneMQ version to 1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM erlang:21 AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.7.0
+ARG VERNEMQ_GIT_REF=1.7.1
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -2,7 +2,7 @@ FROM erlang:21-alpine AS build-env
 
 WORKDIR /vernemq-build
 
-ARG VERNEMQ_GIT_REF=1.7.0
+ARG VERNEMQ_GIT_REF=1.7.1
 ARG TARGET=rel
 ARG VERNEMQ_REPO=https://github.com/vernemq/vernemq.git
 

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.7.0
+appVersion: 1.7.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
 version: 0.2.0

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 3
 
 image:
   repository: erlio/docker-vernemq
-  tag: 1.7.0
+  tag: 1.7.1
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
After the PR is merged we need to tag a new release in the docker-vernemq repo.
