### PR TITLE
Add option to add additional labels, annotation and pod annotations to StatefulSet

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.7.1-1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.1.0
+version: 1.2.0
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -83,6 +83,9 @@ Parameter | Description | Default
 `service.ws.enabled` | whether to expose WebSocket port | `false`
 `service.ws.nodePort` | the WebSocket port exposed by the node when `service.type` is `NodePort` | `8080`
 `service.ws.port` | the WebSocket port exposed by the service | `8080`
+`statefulset.annotations` | additional annotations to the StatefulSet | `{}`
+`statefulset.labels` | additional labels on the StatefulSet | `{}`
+`statefulset.podAnnotations` | additional pod annotations | `{}`
 `statefulset.podManagementPolicy` | start and stop pods in Parallel or OrderedReady (one-by-one.)  **Note** - Cannot change after first release. | `OrderedReady`
 `statefulset.terminationGracePeriodSeconds` | configure how much time VerneMQ takes to move offline queues to other nodes | `60`
 `statefulset.updateStrategy` | Statefulset updateStrategy | `RollingUpdate`

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -7,6 +7,13 @@ metadata:
     helm.sh/chart: {{ include "vernemq.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.statefulset.labels }}
+    {{ toYaml .Values.statefulset.labels | nindent 4 }}
+  {{- end }}
+  {{- with .Values.statefulset.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   serviceName: {{ include "vernemq.fullname" . }}-headless
   replicas: {{ .Values.replicaCount }}
@@ -22,6 +29,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "vernemq.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- with .Values.statefulset.podAnnotations }}
+      annotations:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ include "vernemq.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -131,7 +131,7 @@ statefulset:
     failureThreshold: 3
   podAnnotations: {}
 #    prometheus.io/scrape: "true"
-#    prometheus/io/port: "8888"
+#    prometheus.io/port: "8888"
   annotations: {}
   labels: {}
 

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -129,6 +129,11 @@ statefulset:
     timeoutSeconds: 5
     successThreshold: 1
     failureThreshold: 3
+  podAnnotations: {}
+#    prometheus.io/scrape: "true"
+#    prometheus/io/port: "8888"
+  annotations: {}
+  labels: {}
 
 ## VerneMQ settings
 


### PR DESCRIPTION
This is especially useful to enable automatic scraping of metrics by a Prometheus running in the same Kubernetes cluster than VerneMQ.

This shouldn't introduce retro-compatibility issues