### PR TITLE
Escape the dots in IP_ADDRESS parsing regex

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
+IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
 IP_ADDRESS=${DOCKER_IP_ADDRESS:-${IP_ADDRESS}}
 
 # Ensure the Erlang node name is set correctly


### PR DESCRIPTION
#124 

The fix is to escape the dots in the regex for getting the IP_ADDRESS