### PR TITLE
Helm releasing

### DIFF
--- a/helm/vernemq/.helmignore
+++ b/helm/vernemq/.helmignore
@@ -19,3 +19,4 @@
 .project
 .idea/
 *.tmproj
+RELEASING.md

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: 1.7.1-1
+appVersion: 1.7.1-2
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.2.0
+version: 1.2.1
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/RELEASING.md
+++ b/helm/vernemq/RELEASING.md
@@ -1,0 +1,6 @@
+## How to release the Helm chart
+
+1. Bump the chart version in [Chart.yaml](Chart.yaml) (`version`) by following semantic versioning from the chart point of view
+2. If applicable, bump Docker image version in [values.yaml](values.yaml) (`image.tag`) and [Chart.yaml](Chart.yaml) (`appVersion`)
+3. Tag the last commit `helm-X.X.X` where `X.X.X` is the Chart version like in [Chart.yaml](Chart.yaml)
+4. Push your changes and the tag, Travis will take care of the rest


### PR DESCRIPTION
There has been a problem with the last helm release, the chart version in `Chart.yaml` hasn't been bumped. These commits should fix that and I added some notes to document the Helm chart release process.

The tag `helm-1.2.1` should be pushed again pointing on the last commit once this PR is merged.