### PR TITLE
Add optional ServiceMonitor object to Helm chart

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -89,6 +89,7 @@ Parameter | Description | Default
 `statefulset.podManagementPolicy` | start and stop pods in Parallel or OrderedReady (one-by-one.)  **Note** - Cannot change after first release. | `OrderedReady`
 `statefulset.terminationGracePeriodSeconds` | configure how much time VerneMQ takes to move offline queues to other nodes | `60`
 `statefulset.updateStrategy` | Statefulset updateStrategy | `RollingUpdate`
+`serviceMonitor.enabled` | whether to create a ServiceMonitor for Prometheus Operator | `false`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to helm install. For example,
 

--- a/helm/vernemq/templates/headless-service.yaml
+++ b/helm/vernemq/templates/headless-service.yaml
@@ -10,8 +10,11 @@ metadata:
 spec:
   clusterIP: None
   ports:
-    - port: 4369
-      name: empd
+  - name: empd
+    port: 4369
+  - name: metrics
+    port: 8888
+    targetPort: prometheus
   selector:
     app.kubernetes.io/name: {{ include "vernemq.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/vernemq/templates/servicemonitor.yaml
+++ b/helm/vernemq/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.serviceMonitor.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "vernemq.fullname" . }}
+  labels:
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ template "vernemq.name" . }}
+    helm.sh/chart: {{ template "vernemq.chart" . }}
+spec:
+  endpoints:
+  - interval: 30s
+    port: metrics
+    path: /metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "vernemq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -12,6 +12,9 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+serviceMonitor:
+  create: false
+
 service:
   # NodePort - Listen to a port on nodes and forward to the service.
   # ClusterIP - Listen on the service internal to the cluster only.


### PR DESCRIPTION
Useful for users who have a Prometheus Operator instance configured on
their cluster. Disabled by default, as the ServiceMonitor CRD must exist
already.

Also had to add a Service port that points to the Prometheus metrics
port (which already existed on the container).

Tested as a local chart on our Kubernetes cluster running Prometheus Operator, seems to work just fine.