### PR TITLE
Feature/enable clustering in kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_N
 > WAIT_FOR_ERLANG to the number of seconds to wait.
 > ...
 > ```
+If using an vernemq.conf.local file, you can insert a placeholder (`###IPADDRESS###`) in your config to be replaced (at POD creation time) with the actual IP address of the POD vernemq is running on, making VMQ clustering possible.
 
 ### Checking cluster status
 

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -55,6 +55,7 @@ fi
 
 if [ -f /vernemq/etc/vernemq.conf.local ]; then
     cp /vernemq/etc/vernemq.conf.local /vernemq/etc/vernemq.conf
+    sed -i -r "s/###IPADDRESS###/${IP_ADDRESS}/" /vernemq/etc/vernemq.conf
 else
     sed -i '/########## Start ##########/,/########## End ##########/d' /vernemq/etc/vernemq.conf
 


### PR DESCRIPTION
This PR fixes running in kubernetes with clustering enabled and working when using the `vernemq.conf.local` mechanism from the `vernemq.sh` entrypoint script. It replaces all occurrences of the string `###IPADDRESS###` with the actual POD IP in situ. When the string does not occur in the vernemq.conf.local, it does nothing making this approach fully backwards compatible. 