### PR TITLE
Fix Docker Swarm / Compose support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,32 @@ When enabling Kubernetes autoclustering, don't set ```DOCKER_VERNEMQ_DISCOVERY_N
 > ```
 If using an vernemq.conf.local file, you can insert a placeholder (`###IPADDRESS###`) in your config to be replaced (at POD creation time) with the actual IP address of the POD vernemq is running on, making VMQ clustering possible.
 
+### 4. Using [Docker Swarm](https://docs.docker.com/engine/swarm/)
+
+Please follow the official Docker guide to properly setup Swarm cluster with one or more nodes.
+
+Once Swarm is setup you can deploy a VerneMQ stack. The following snippet describes the stack using a `docker-compose.yml` file:
+
+    version: "3.7"
+    services:
+      vmq0:
+        image: erlio/docker-vernemq
+        environment:
+          DOCKER_VERNEMQ_SWARM: 1
+      vmq:
+        image: erlio/docker-vernemq
+        depends_on:
+          - vmq0
+        environment:
+          DOCKER_VERNEMQ_SWARM: 1
+          DOCKER_VERNEMQ_DISCOVERY_NODE: vmq0
+        deploy:
+          replicas: 2
+
+Run `docker stack deploy -c docker-compose.yml my-vernemq-stack` to deploy a 3 node VerneMQ cluster.
+
+Note: Docker Swarm currently lacks the functionality similar to what is called a statefulset in Kubernetes. As a consequence VerneMQ must rely on a specific discovery service (the `vmq0` service above) that is started before the other replicas.
+
 ### Checking cluster status
 
 To check if the above containers have successfully clustered you can issue the ```vmq-admin``` command:


### PR DESCRIPTION
First. A big apology for not taking the issues relating to automatic clustering on Docker Swarm (and also Docker Compose) more seriously. While workarounds certainly exist, they are not as straight-forward as expected. I aim to fix that with this PR.

One downside of clustering VerneMQ with Docker Swarm is that one can not rely on predictable start order as well as predictable naming (as used with Kubernetes Statefulsets). As a consequence one requires to start a service to bootstrap the cluster e.g. the following:

```yaml
version: "3.7"
services:
  vmq0:
    image: erlio/docker-vernemq
    environment:
      DOCKER_VERNEMQ_SWARM: 1
  vmq:
    image: erlio/docker-vernemq
    depends_on:
      - vmq0
    environment:
      DOCKER_VERNEMQ_SWARM: 1
      DOCKER_VERNEMQ_DISCOVERY_NODE: vmq0
    deploy:
      replicas: 2
```
The `depends_on` property ensures that the bootstrapping service `vmq0` is reachable by the other containers and can be used to discover the cluster. The `docker stack deploy -c <compose file above> my-stack` results in a 3 node VerneMQ cluster. While I'd prefer a solution that doesn't require an extra service for discovery, it's a compromise that we currently have to live with until we can realize our plans with `vmq_discovery`.

Additionally: Use `DOCKER_VERNEMQ_COMPOSE: 1` instead of `DOCKER_VERNEMQ_SWARM: 1` if you are in a plain compose setup.

Fixes #115 
Fixes #43 
Fixes #57 
Properly fixes https://github.com/vernemq/vernemq/issues/1025

Thanks for your patience, your bug reports, and other contributions.