### PR TITLE
Ensure clones contains enough information for git describe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
 
 RUN apt-get update && \
     apt-get -y install build-essential git libssl-dev && \
-    git clone -b $VERNEMQ_GIT_REF --single-branch --depth 1 $VERNEMQ_REPO .
+    git clone -b $VERNEMQ_GIT_REF $VERNEMQ_REPO .
 
 COPY bin/build.sh build.sh
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -12,7 +12,7 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
 
 RUN apk --no-cache --update --available upgrade && \
     apk add --no-cache git autoconf build-base bsd-compat-headers cmake openssl-dev bash && \
-    git clone -b $VERNEMQ_GIT_REF --single-branch --depth 1 $VERNEMQ_REPO .
+    git clone -b $VERNEMQ_GIT_REF $VERNEMQ_REPO .
 
 COPY bin/build.sh build.sh
 


### PR DESCRIPTION
With this I'm able to build vernemq from master rather than a tag. The snag was relx which does a `git describe` which we can't control, so we need a full clone...