### PR TITLE
Use correct new path to the Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,21 @@ For more information, check out the Helm chart [README](helm/vernemq/README.md).
 
 ### 2. Using pure Docker commands
 
-    docker run --name vernemq1 -d erlio/docker-vernemq
+    docker run --name vernemq1 -d vernemq/vernemq
 
 Somtimes you need to configure a forwarding for ports (on a Mac for example):
 
-    docker run -p 1883:1883 --name vernemq1 -d erlio/docker-vernemq
+    docker run -p 1883:1883 --name vernemq1 -d vernemq/vernemq
 
 This starts a new node that listens on 1883 for MQTT connections and on 8080 for MQTT over websocket connections. However, at this moment the broker won't be able to authenticate the connecting clients. To allow anonymous clients use the ```DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on``` environment variable.
 
-    docker run -e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on" --name vernemq1 -d erlio/docker-vernemq
+    docker run -e "DOCKER_VERNEMQ_ALLOW_ANONYMOUS=on" --name vernemq1 -d vernemq/vernemq
 
 #### Autojoining a VerneMQ cluster
 
 This allows a newly started container to automatically join a VerneMQ cluster. Assuming you started your first node like the example above you could autojoin the cluster (which currently consists of a single container 'vernemq1') like the following:
 
-    docker run -e "DOCKER_VERNEMQ_DISCOVERY_NODE=<IP-OF-VERNEMQ1>" --name vernemq2 -d erlio/docker-vernemq
+    docker run -e "DOCKER_VERNEMQ_DISCOVERY_NODE=<IP-OF-VERNEMQ1>" --name vernemq2 -d vernemq/vernemq
 
 (Note, you can find the IP of a docker container using `docker inspect <containername/cid> | grep \"IPAddress\"`).
 
@@ -92,11 +92,11 @@ Once Swarm is setup you can deploy a VerneMQ stack. The following snippet descri
     version: "3.7"
     services:
       vmq0:
-        image: erlio/docker-vernemq
+        image: vernemq/vernemq
         environment:
           DOCKER_VERNEMQ_SWARM: 1
       vmq:
-        image: erlio/docker-vernemq
+        image: vernemq/vernemq
         depends_on:
           - vmq0
         environment:


### PR DESCRIPTION
I noticed that the `README` on [Dockerhub](https://hub.docker.com/r/vernemq/vernemq/) still shows the old path to the Docker image.

This pull request fixes that and uses the correct and current path.