### PR TITLE
Add an empty check of additionalEnv list

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -76,7 +76,9 @@ spec:
             - name: DOCKER_VERNEMQ_LISTENER__SSL__DEFAULT
               value: "$(MY_POD_IP):{{ .Values.service.mqtts.port }}"
             {{- end }}
+            {{- if .Values.additionalEnv }}
             {{ toYaml .Values.additionalEnv | nindent 12 }}
+            {{- end }}
           resources:
             {{ toYaml .Values.resources | nindent 12 }}
           livenessProbe:


### PR DESCRIPTION
If an empty `additionalEnv` list is specified in values.yaml
Example:
``` 
additionalEnv: []
```
Then you will end up with a generated manifest that contains null string inside your env list
Example:
```
  env:
    - name: MY_POD_NAME
      valueFrom:
	fieldRef:
	  fieldPath: metadata.name
    - name: MY_POD_IP
      valueFrom:
	fieldRef:
	  fieldPath: status.podIP
    - name: DOCKER_VERNEMQ_DISCOVERY_KUBERNETES
      value: "1"
    - name: DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR
      value: "app.kubernetes.io/name=vernemq,app.kubernetes.io/instance=release-name"
    - name: DOCKER_VERNEMQ_LISTENER__TCP__LOCALHOST
      value: "127.0.0.1:1883"

    null
```
This manifest will be invalid and will provide an error during deployment
> error: error parsing STDIN: error converting YAML to JSON: yaml: line 81: could not find expected ':'

Checking for an empty list with `{{- if .Values.additionalEnv }}` will fix this.