### PR TITLE
Fix SSL listen port

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -74,7 +74,7 @@ spec:
               value: "127.0.0.1:1883"
             {{- if .Values.service.mqtts.enabled }}
             - name: DOCKER_VERNEMQ_LISTENER__SSL__DEFAULT
-              value: "$(MY_POD_IP):{{ .Values.service.mqtts.port }}"
+              value: "$(MY_POD_IP):8883"
             {{- end }}
             {{- if .Values.additionalEnv }}
             {{ toYaml .Values.additionalEnv | nindent 12 }}


### PR DESCRIPTION
This PR fixes a bug that prevents the SSL listener from working properly when using a non-default `mqtts` port via the `service.mqtts.port` setting (for example, port 443 instead of 8883).