### PR TITLE
Refactor the statefulset probes

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.10.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.5.1
+version: 1.6.1
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.10.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.6.1
+version: 1.6.0
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -82,22 +82,20 @@ spec:
           resources:
             {{ toYaml .Values.resources | nindent 12 }}
           livenessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - "-c"
-                - "/vernemq/bin/vernemq ping | grep pong"
+            httpGet:
+              path: /health
+              port: prometheus
+              scheme: HTTP
             initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.statefulset.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.statefulset.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.statefulset.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
           readinessProbe:
-            exec:
-              command:
-                - /bin/sh
-                - "-c"
-                - "/vernemq/bin/vernemq ping | grep pong"
+            httpGet:
+              path: /health
+              port: prometheus
+              scheme: HTTP
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.statefulset.readinessProbe.timeoutSeconds }}


### PR DESCRIPTION
Leverage the prometheus metrics endpoint instead of execing to do
liveness and readiness probes, to reduce overall CPU usage and follow
best-practices

fixes #165