### PR TITLE
Add PodDisruptionBudget

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.10.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.6.0
+version: 1.6.1
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -91,6 +91,9 @@ Parameter | Description | Default
 `statefulset.terminationGracePeriodSeconds` | configure how much time VerneMQ takes to move offline queues to other nodes | `60`
 `statefulset.updateStrategy` | Statefulset updateStrategy | `RollingUpdate`
 `serviceMonitor.enabled` | whether to create a ServiceMonitor for Prometheus Operator | `false`
+`pdb.enabled` | whether to create a Pod Disruption Budget | `false`
+`pdb.minAvailable` | PDB (min available) for the cluster | `1`
+`pdb.maxUnavailable` | PDB (max unavailable) for the cluster | `nil`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to helm install. For example,
 

--- a/helm/vernemq/templates/poddisruptionbudget.yaml
+++ b/helm/vernemq/templates/poddisruptionbudget.yaml
@@ -1,0 +1,23 @@
+{{ if and .Values.pdb .Values.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "vernemq.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ include "vernemq.name" . }}
+    helm.sh/chart: {{ include "vernemq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "vernemq.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.pdb.minAvailable }}
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if .Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  {{- end }}
+{{- end }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -145,6 +145,11 @@ statefulset:
   annotations: {}
   labels: {}
 
+pdb:
+  enabled: false
+  minAvailable: 1
+  # maxUnavailable: 1
+
 ## VerneMQ settings
 
 additionalEnv:


### PR DESCRIPTION
This PR adds support for PDB in order to provide a number of disruptions that can be tolerated at a given time for a class of pods (a budget of faults).