### PR TITLE
#192 fix cluster leave for kubernetes nodes in sigterm_handler

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -131,7 +131,11 @@ siguser1_handler() {
 sigterm_handler() {
     if [ $pid -ne 0 ]; then
         # this will stop the VerneMQ process
-        /vernemq/bin/vmq-admin cluster leave node=VerneMQ@$IP_ADDRESS -k > /dev/null
+        if [ ! -z $VERNEMQ_KUBERNETES_HOSTNAME ]; then
+            /vernemq/bin/vmq-admin cluster leave node=$VERNEMQ_KUBERNETES_HOSTNAME-k > /dev/null
+        else
+            /vernemq/bin/vmq-admin cluster leave node=VerneMQ@$IP_ADDRESS -k > /dev/null
+        fi
         wait "$pid"
     fi
     exit 143; # 128 + 15 -- SIGTERM

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -130,12 +130,15 @@ siguser1_handler() {
 # SIGTERM-handler
 sigterm_handler() {
     if [ $pid -ne 0 ]; then
-        # this will stop the VerneMQ process
-        if [ ! -z $VERNEMQ_KUBERNETES_HOSTNAME ]; then
-            /vernemq/bin/vmq-admin cluster leave node=$VERNEMQ_KUBERNETES_HOSTNAME-k > /dev/null
+        # this will stop the VerneMQ process, but first drain the node from all existing client sessions (-k)
+        if [ -n "$VERNEMQ_KUBERNETES_HOSTNAME" ]; then
+            terminating_node_name=$VERNEMQ_KUBERNETES_HOSTNAME
+        elif [ -n "$DOCKER_VERNEMQ_SWARM" ]; then
+            terminating_node_name=VerneMQ@$NODENAME
         else
-            /vernemq/bin/vmq-admin cluster leave node=VerneMQ@$IP_ADDRESS -k > /dev/null
+            terminating_node_name=VerneMQ@$IP_ADDRESS
         fi
+        /vernemq/bin/vmq-admin cluster leave node=$terminating_node_name -k > /dev/null
         wait "$pid"
     fi
     exit 143; # 128 + 15 -- SIGTERM

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -134,7 +134,7 @@ sigterm_handler() {
         if [ -n "$VERNEMQ_KUBERNETES_HOSTNAME" ]; then
             terminating_node_name=$VERNEMQ_KUBERNETES_HOSTNAME
         elif [ -n "$DOCKER_VERNEMQ_SWARM" ]; then
-            terminating_node_name=VerneMQ@$NODENAME
+            terminating_node_name=VerneMQ@$(hostname -i)
         else
             terminating_node_name=VerneMQ@$IP_ADDRESS
         fi


### PR DESCRIPTION
This change allows cluster nodes based on kubernetes using a nodename instead of an IP address to leave the cluster and migrate their client sessions to other hosts before being terminated. 

[Issue 192](https://github.com/vernemq/docker-vernemq/issues/192) shows all the details.

Thanks for considering merging this change!