### PR TITLE
Allow optional Ingress to the WebSocket service

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -52,8 +52,14 @@ Parameter | Description | Default
 --------- | ----------- | -------
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
-`image.repository` | container image repository | `erlio/docker-vernemq`
+`image.repository` | container image repository | `vernemq/vernemq`
 `image.tag` | container image tag | the current versions (e.g. `1.10.2`)
+`ingress.enabled` | whether to enable an ingress object to route to the WebSocket service. Requires an ingress controller and the WebSocket service to be enabled. | `false`
+`ingress.labels` | additional ingress labels | `{}`
+`ingress.annotations` | additional service annotations | `{}`
+`ingress.hosts` | a list of routable hostnames for host-based routing of traffic to the WebSocket service | `[]`
+`ingress.paths` | a list of paths for path-based routing of traffic to the WebSocket service | `/`
+`ingress.tls` | a list of TLS ingress configurations for securing the WebSocket ingress | `[]`
 `nodeSelector` | node labels for pod assignment | `{}`
 `persistentVolume.accessModes` | data Persistent Volume access modes | `[ReadWriteOnce]`
 `persistentVolume.annotations` | annotations for Persistent Volume Claim | `{}`

--- a/helm/vernemq/templates/ingress.yaml
+++ b/helm/vernemq/templates/ingress.yaml
@@ -1,0 +1,48 @@
+{{- if and .Values.ingress.enabled .Values.service.ws.enabled }}
+{{- $servicePort := .Values.service.ws.port -}}
+{{- $paths := .Values.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ include "vernemq.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "vernemq.name" . }}
+    helm.sh/chart: {{ include "vernemq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+{{- with .Values.ingress.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  rules:
+  {{- if .Values.ingress.hosts }}
+  {{- range $host := .Values.ingress.hosts }}
+  - host: {{ tpl $host $ }}
+    http:
+      paths:
+  {{- range $path := $paths }}
+      - path: {{ tpl $path $ }}
+        backend:
+          serviceName: {{ include "vernemq.fullname" $ }}
+          servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
+  {{- else }}
+  - http:
+      paths:
+  {{- range $path := $paths }}
+      - path: {{ tpl $path $ }}
+        backend:
+          serviceName: {{ include "vernemq.fullname" $ }}
+          servicePort: {{ $servicePort }}
+  {{- end -}}
+  {{- end -}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{ toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -44,6 +44,36 @@ service:
   annotations: {}
   labels: {}
 
+## Ingress can optionally be applied when enabling the MQTT websocket service
+## This allows for an ingress controller to route web ports and arbitrary hostnames
+## and paths to the websocket service as well as allow the controller to handle TLS
+## termination for the websocket traffic. Ingress is only possible for traffic exchanged
+## over HTTP, so ONLY the websocket service take advantage of ingress.
+ingress:
+  enabled: false
+
+  labels: {}
+
+  annotations: {}
+
+  ## Hosts must be provided if ingress is enabled.
+  ##
+  hosts: []
+    # - vernemq.domain.com
+
+  ## Paths to use for ingress rules - one path should match the ingress.routePrefix
+  ##
+  paths:
+    - /
+
+  ## TLS configuration for ingress
+  ## Secret must be manually created in the namespace
+  ##
+  tls: []
+  # - secretName: vernemq-tls
+  #   hosts:
+  #   - vernemq.domain.com
+
 ## VerneMQ resources requests and limits
 ## Ref: http://kubernetes.io/docs/user-guide/compute-resources
 resources: {}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -61,7 +61,7 @@ ingress:
   hosts: []
     # - vernemq.domain.com
 
-  ## Paths to use for ingress rules - one path should match the ingress.routePrefix
+  ## Paths to use for ingress rules.
   ##
   paths:
     - /


### PR DESCRIPTION
This PR allows creation of an optional Ingress object for routing to the WebSocket service.
Ingress _and_ websocket service must both be enabled for the ingress object to be created. Ingress controller is separately required for the ingress object to take effect but it is safe to create an ingress without an ingress controller installed in the cluster.

I attempted to follow the conventions for labeling and indenting already present in other templates with the exception of preferring `indent` instead of `nindent` in the annotations and labels as I found this created additional empty newlines when rendering the template.