### PR TITLE
Fix incorrect sigterm handling in entrypoint

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -139,9 +139,10 @@ sigterm_handler() {
             terminating_node_name=VerneMQ@$IP_ADDRESS
         fi
         /vernemq/bin/vmq-admin cluster leave node=$terminating_node_name -k > /dev/null
-        wait "$pid"
+        /vernemq/bin/vmq-admin node stop > /dev/null
+        kill -s TERM ${pid}
+        exit 0
     fi
-    exit 143; # 128 + 15 -- SIGTERM
 }
 
 # Setup OS signal handlers
@@ -149,6 +150,6 @@ trap 'siguser1_handler' SIGUSR1
 trap 'sigterm_handler' SIGTERM
 
 # Start VerneMQ
-/vernemq/bin/vernemq console -noshell -noinput $@
-pid=$(ps aux | grep '[b]eam.smp' | awk '{print $2}')
+/vernemq/bin/vernemq console -noshell -noinput $@ &
+pid=$!
 wait $pid


### PR DESCRIPTION
Closes #191

Container was not stopping gracefully, and it eventually got killed.

Entrypoint script launches VerneMQ process on the foreground. As the shell is busy with that command, it can't handle the SIGTERM sent by the Docker daemon on `docker stop`.

This PR modifies this behaviour so that the process is started on the background and waited for it to finish, so the shell script doesn't exit. `wait` calls can be interrupted in Bash with signal traps, so the stop command can be then sent with the `vmq-admin` command.

Also, the exit code on `stop` is changed to `0`. If different than 0, the Docker daemon complains of a unclean exit.