### PR TITLE
Add missing VerneMQ@ to terminating node name

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -132,7 +132,7 @@ sigterm_handler() {
     if [ $pid -ne 0 ]; then
         # this will stop the VerneMQ process, but first drain the node from all existing client sessions (-k)
         if [ -n "$VERNEMQ_KUBERNETES_HOSTNAME" ]; then
-            terminating_node_name=$VERNEMQ_KUBERNETES_HOSTNAME
+            terminating_node_name=VerneMQ@$VERNEMQ_KUBERNETES_HOSTNAME
         elif [ -n "$DOCKER_VERNEMQ_SWARM" ]; then
             terminating_node_name=VerneMQ@$(hostname -i)
         else


### PR DESCRIPTION
This has gone unnoticed since 'vmq-admin cluster leave' command succeeds regardless of whether the node name is correct or not.