### PR TITLE
Release Helm chart version 1.6.2-1 to use VerneMQ image 1.10.2-1

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.10.2-1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.6.2
+version: 1.6.2-1
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -53,7 +53,7 @@ Parameter | Description | Default
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `vernemq/vernemq`
-`image.tag` | container image tag | the current versions (e.g. `1.10.2`)
+`image.tag` | container image tag | the current versions (e.g. `1.10.2-1`)
 `ingress.enabled` | whether to enable an ingress object to route to the WebSocket service. Requires an ingress controller and the WebSocket service to be enabled. | `false`
 `ingress.labels` | additional ingress labels | `{}`
 `ingress.annotations` | additional service annotations | `{}`


### PR DESCRIPTION
The latest version deployed on helm has the issue with libsnappy, this will fix it. Fixes #214 