### PR TITLE
fix label selector for affinity rules

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v1
 appVersion: 1.10.3
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.6.3
+version: 1.6.4
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -129,14 +129,10 @@ spec:
             - topologyKey: "kubernetes.io/hostname"
               labelSelector:
                 matchExpressions:
-                  - key: "app"
+                  - key: "app.kubernetes.io/name"
                     operator: In
                     values:
                       - {{ include "vernemq.name" . }}
-                  - key: "release"
-                    operator: In
-                    values:
-                      - {{ .Release.Name }}
     {{- else if eq .Values.podAntiAffinity "soft" }}
       affinity:
         podAntiAffinity:
@@ -146,14 +142,10 @@ spec:
                 topologyKey: "kubernetes.io/hostname"
                 labelSelector:
                   matchExpressions:
-                    - key: "app"
+                    - key: "app.kubernetes.io/name"
                       operator: In
                       values:
                         - {{ include "vernemq.name" . }}
-                    - key: "release"
-                      operator: In
-                      values:
-                        - {{ .Release.Name }}
     {{- end }}
     {{- with .Values.tolerations }}
       tolerations:


### PR DESCRIPTION
The `labelSelector` for the affinity rules did not match the actual labels used in the statefulset, and thus the affinity flags didn't work. 
 This pull request fixes that condition.
