### PR TITLE
Automatically find default net interface

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
-IP_ADDRESS=$(ip -4 addr show ${DOCKER_NET_INTERFACE:-eth0} | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
+NET_INTERFACE=$(route | grep '^default' | grep -o '[^ ]*$')
+NET_INTERFACE=${DOCKER_NET_INTERFACE:-${NET_INTERFACE}}
+IP_ADDRESS=$(ip -4 addr show ${NET_INTERFACE} | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
 IP_ADDRESS=${DOCKER_IP_ADDRESS:-${IP_ADDRESS}}
 
 # Ensure the Erlang node name is set correctly


### PR DESCRIPTION
Currently the `vernemq.sh` script assumes the net interface to be `eth0` when not setting the `DOCKER_NET_INTERFACE` env variable. This is problematic in non default docker environments where such an interface is not available (main use case is when setting `--net host`).

This PR changes that to extract the _default_ net interface from the output of `route`. For normal docker containers this changes nothing, since `eth0` is the output.