### PR TITLE
Install net-tools in the debian Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch-slim
 
 RUN apt-get update && \
-    apt-get -y install bash procps openssl iproute2 curl jq libsnappy-dev && \
+    apt-get -y install bash procps openssl iproute2 curl jq libsnappy-dev net-tools && \
     rm -rf /var/lib/apt/lists/* && \
     addgroup --gid 10000 vernemq && \
     adduser --uid 10000 --system --ingroup vernemq --home /vernemq --disabled-password vernemq


### PR DESCRIPTION
Follow up for https://github.com/vernemq/docker-vernemq/pull/222.

The new call to `route` requires `net-tools` to be installed in the debian Dockerfile. For alpine, no changes are required because the command is available there.

Tested locally with both Dockerfiles.