### PR TITLE
Support secure websocket listener

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -94,6 +94,9 @@ Parameter | Description | Default
 `service.ws.enabled` | whether to expose WebSocket port | `false`
 `service.ws.nodePort` | the WebSocket port exposed by the node when `service.type` is `NodePort` | `8080`
 `service.ws.port` | the WebSocket port exposed by the service | `8080`
+`service.wss.enabled` | whether to expose secure WebSocket port | `false`
+`service.wss.nodePort` | the secure WebSocket port exposed by the node when `service.type` is `NodePort` | `8443`
+`service.wss.port` | the secure WebSocket port exposed by the service | `8443`
 `statefulset.annotations` | additional annotations to the StatefulSet | `{}`
 `statefulset.labels` | additional labels on the StatefulSet | `{}`
 `statefulset.podAnnotations` | additional pod annotations | `{}`

--- a/helm/vernemq/templates/service.yaml
+++ b/helm/vernemq/templates/service.yaml
@@ -68,6 +68,14 @@ spec:
       nodePort: {{ .Values.service.ws.nodePort }}
       {{- end }}
     {{- end }}
+    {{- if .Values.service.wss.enabled }}
+    - port: {{ .Values.service.wss.port }}
+      targetPort: wss
+      name: wss
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.wss.nodePort }}
+      {{- end }}
+    {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "vernemq.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -51,6 +51,8 @@ spec:
               name: vmq
             - containerPort: 8080
               name: ws
+            - containerPort: 8443
+              name: wss
             - containerPort: 8888
               name: prometheus
             {{- range tuple 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109 }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -41,6 +41,11 @@ service:
     port: 8080
     # This is the port used by nodes to expose the service
     nodePort: 8080
+  wss:
+    enabled: false
+    port: 8443
+    # This is the port used by nodes to expose the service
+    nodePort: 8443
   annotations: {}
   labels: {}
 


### PR DESCRIPTION
This PR adds support for the secure websocket listener in the Helm chart.

Fixes #171