### PR TITLE
Enable Container run with readonly root filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get -y install bash procps openssl iproute2 curl jq libsnappy-dev net-tools && \
     rm -rf /var/lib/apt/lists/* && \
     addgroup --gid 10000 vernemq && \
-    adduser --uid 10000 --system --ingroup vernemq --home /vernemq --disabled-password vernemq
+    adduser --uid 10000 --system --ingroup vernemq --home /vernemq/data/home --disabled-password vernemq
 
 WORKDIR /vernemq
 

--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -130,6 +130,9 @@ EOF
     echo "########## End ##########" >> /vernemq/etc/vernemq.conf
 fi
 
+mkdir -p /vernemq/data/home
+chmod g-rwx /vernemq/data/home/.erlang.cookie
+
 # Check configuration file
 /vernemq/bin/vernemq config generate 2>&1 > /dev/null | tee /tmp/config.out | grep error
 


### PR DESCRIPTION
Therefore moved home directory into data volume and fix right of Erlang Cookie in case of reclaiming a volume on kubernetes.

fixes: #243