### PR TITLE
Turn Persistent volume on by default

### DIFF
--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -123,7 +123,7 @@ rbac:
 persistentVolume:
   ## If true, VerneMQ will create/use a Persistent Volume Claim
   ## If false, use local directory
-  enabled: false
+  enabled: true
 
   ## VerneMQ data Persistent Volume access modes
   ## Must match those of existing PV or dynamic provisioner


### PR DESCRIPTION
In the list of the default values in the README file, the `persistentVolume.enabled` is said to be true, while in the `values.yaml` its default value is `false`. This pull request fixes it.