### PR TITLE
Use cURL vs ADD to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
 
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq
 COPY --chown=10000:10000 files/vm.args /vernemq/etc/vm.args
-ADD https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSION/vernemq-$VERNEMQ_VERSION.stretch.tar.gz /tmp
 
-RUN tar -xzvf /tmp/vernemq-$VERNEMQ_VERSION.stretch.tar.gz && \
+RUN curl -L https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSION/vernemq-$VERNEMQ_VERSION.stretch.tar.gz -o /tmp/vernemq-$VERNEMQ_VERSION.stretch.tar.gz && \
+    tar -xzvf /tmp/vernemq-$VERNEMQ_VERSION.stretch.tar.gz && \
     rm /tmp/vernemq-$VERNEMQ_VERSION.stretch.tar.gz && \
     chown -R 10000:10000 /vernemq && \
     ln -s /vernemq/etc /etc/vernemq && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -16,9 +16,9 @@ WORKDIR /vernemq
 
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq
 COPY --chown=10000:10000 files/vm.args /vernemq/etc/vm.args
-ADD https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSION/vernemq-$VERNEMQ_VERSION.alpine.tar.gz /tmp
 
-RUN tar -xzvf /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
+RUN curl -L https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSION/vernemq-$VERNEMQ_VERSION.alpine.tar.gz -o /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
+    tar -xzvf /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
     rm /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
     chown -R 10000:10000 /vernemq && \
     ln -s /vernemq/etc /etc/vernemq && \


### PR DESCRIPTION
Fixes Issue #251

Reduce Docker image size by using `cURL` vs Docker `ADD`

Note these changes were build with image name `vernemq-mod` and `vernemq-alpine-mod`. I have included the original images for comparison.
```
REPOSITORY                                               TAG                 IMAGE ID            CREATED             SIZE
vernemq-mod                                              latest              28f365105a29        26 seconds ago      143MB
vernemq-alpine-mod                                       latest              a473f8e8dfbb        2 seconds ago       57.9MB
erlio/docker-vernemq                                     latest              c313a97d3038        10 months ago       166MB
erlio/docker-vernemq                                     latest-alpine       8c0340a2a64e        10 months ago       83.8MB
```