### PR TITLE
Support setting externalTrafficPolicy on VerneMQ service

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -82,6 +82,7 @@ Parameter | Description | Default
 `service.labels` | additional service labels | `{}`
 `service.loadBalancerIP` | optional load balancer IP when `service.type` is `LoadBalancer` | `none`
 `service.loadBalancerSourceRanges` | optional load balancer source ranges when `service.type` is `LoadBalancer` | `none`
+`service.externalTrafficPolicy` | set this to `Local` to preserve client source IPs and prevent additional hops between K8s nodes if the service type is `LoadBalancer` or `NodePort` | `unset`
 `service.sessionAffinity` | service session affinity | `none`
 `service.sessionAffinityConfig` | service session affinity config | `none`
 `service.mqtt.enabled` | whether to expose MQTT port | `true`

--- a/helm/vernemq/templates/service.yaml
+++ b/helm/vernemq/templates/service.yaml
@@ -32,6 +32,9 @@ spec:
 {{- else }}
   type: {{ .Values.service.type }}
 {{- end }}
+{{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+{{- end }}
 {{- if .Values.service.sessionAffinity }}
   sessionAffinity: {{ .Values.service.sessionAffinity }}
   {{- if .Values.service.sessionAffinityConfig }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -24,6 +24,7 @@ service:
 #  externalIPs: []
 #  loadBalancerIP: 10.1.2.4
 #  loadBalancerSourceRanges: []
+#  externalTrafficPolicy: Local
 #  sessionAffinity: None
 #  sessionAffinityConfig: {}
   mqtt:


### PR DESCRIPTION
With this PR it will be possible to set the externalTrafficPolicy property on the VerneMQ service.