### PR TITLE
helm-chart: Added the option to use envFrom in the statefulset

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -51,6 +51,7 @@ The following table lists the configurable parameters of the VerneMQ chart and t
 Parameter | Description | Default
 --------- | ----------- | -------
 `additionalEnv` | additional environment variables | see [values.yaml](values.yaml)
+`envFrom` | additional envFrom configmaps or secrets | see [values.yaml](values.yaml)
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `vernemq/vernemq`
 `image.tag` | container image tag | the current versions (e.g. `1.11.0`)

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -85,6 +85,8 @@ spec:
             {{- if .Values.additionalEnv }}
             {{ toYaml .Values.additionalEnv | nindent 12 }}
             {{- end }}
+          envFrom:
+            {{ toYaml .Values.envFrom | nindent 12 }}
           resources:
             {{ toYaml .Values.resources | nindent 12 }}
           livenessProbe:

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -225,3 +225,9 @@ additionalEnv:
 #    value: "/etc/ssl/vernemq/tls.crt"
 #  - name: DOCKER_VERNEMQ_LISTENER__SSL__KEYFILE
 #    value: "/etc/ssl/vernemq/tls.key"
+
+envFrom: {}
+# add additional environment variables e.g. from a configmap or secret
+# can be usefull if you wanna use authentication via files
+#  - secretRef:
+#      name: vernemq-users


### PR DESCRIPTION
so we can publish environment variables from a secret. This can be
useful using auth using files:

Create the secret by yourself e.g sealed secrets or mozilla sop:

```yaml
---
apiVersion: v1
kind: Secret
metadata:
  name: vernemq-users
  namespace: vernemq
type: Opaque
stringData:
  DOCKER_VERNEMQ_USER_myUser: TopSecurePassword
```

and use it from the helm chart / values.yaml:

```yaml
envFrom:
  - secretRef:
      name: vernemq-users
```