### PR TITLE
Add Helm value to specify the image pull secrets for the Pod

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -54,6 +54,7 @@ Parameter | Description | Default
 `image.pullPolicy` | container image pull policy | `IfNotPresent`
 `image.repository` | container image repository | `vernemq/vernemq`
 `image.tag` | container image tag | the current versions (e.g. `1.11.0`)
+`imagePullSecrets` | Image pull secrets for the Pod | `[]`
 `ingress.enabled` | whether to enable an ingress object to route to the WebSocket service. Requires an ingress controller and the WebSocket service to be enabled. | `false`
 `ingress.labels` | additional ingress labels | `{}`
 `ingress.annotations` | additional service annotations | `{}`

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -124,6 +124,10 @@ spec:
           lifecycle:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{ toYaml . | nindent 8 }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: 1.11.0-alpine
   pullPolicy: IfNotPresent
 
+# Image pull secrets for the Pod
+imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Make it possible to pull the Docker image from a private registry.
