### PR TITLE
Add the ability to set imagePullSecrets

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -34,6 +34,10 @@ spec:
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "vernemq.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}
       containers:

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -9,6 +9,9 @@ image:
   tag: 1.11.0-alpine
   pullPolicy: IfNotPresent
 
+imagePullSecrets: {} 
+# - name: regcred
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
... for pulling from a private Docker repository.

Addresses issue:
#280 

Tests run:

1. values.yaml input
```
imagePullSecrets: {} 
# - name: regcred

```
output:
```
spec:
  serviceAccountName: RELEASE-NAME-vernemq
```

2. values.yaml input
```
# imagePullsSecrets:
```
output:
```
spec:
  serviceAccountName: RELEASE-NAME-vernemq
```
3. values.yaml input
```
imagePullSecrets:
- name: regcred
```
output:
```
spec:
  imagePullSecrets:
    - name: regcred
  serviceAccountName: RELEASE-NAME-vernemq
```

