### PR TITLE
Change default 'envFrom' value to array

### DIFF
--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -226,7 +226,7 @@ additionalEnv:
 #  - name: DOCKER_VERNEMQ_LISTENER__SSL__KEYFILE
 #    value: "/etc/ssl/vernemq/tls.key"
 
-envFrom: {}
+envFrom: []
 # add additional environment variables e.g. from a configmap or secret
 # can be usefull if you wanna use authentication via files
 #  - secretRef:


### PR DESCRIPTION
Fixes:

> Error: unable to build kubernetes objects from release manifest: error validating "": error validating data: ValidationError(StatefulSet.spec.template.spec.containers[0].envFrom): invalid type for io.k8s.api.core.v1.Container.envFrom: got "map", expected "array"