### PR TITLE
More bash cleanup. Fixing k8s handling of pod restarts.

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -1,12 +1,5 @@
 #!/usr/bin/env bash
 
-# Check istio readiness
-istio_health() {
-  cmd=$(curl -s http://localhost:15021/healthz/ready > /dev/null)
-  status=$?
-  return $status
-}
-
 NET_INTERFACE=$(route | grep '^default' | grep -o '[^ ]*$')
 NET_INTERFACE=${DOCKER_NET_INTERFACE:-${NET_INTERFACE}}
 IP_ADDRESS=$(ip -4 addr show ${NET_INTERFACE} | grep -oE '[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}' | sed -e "s/^[[:space:]]*//" | head -n 1)
@@ -18,9 +11,46 @@ VERNEMQ_CONF_FILE="${VERNEMQ_ETC_DIR}/vernemq.conf"
 VERNEMQ_CONF_LOCAL_FILE="${VERNEMQ_ETC_DIR}/vernemq.conf.local"
 
 SECRETS_KUBERNETES_DIR="/var/run/secrets/kubernetes.io/serviceaccount"
-CA_CRT_FILE="${SECRETS_KUBERNETES_DIR}/ca.crt"
-NAMESPACE_FILE="${SECRETS_KUBERNETES_DIR}/namespace"
-TOKEN_FILE="${SECRETS_KUBERNETES_DIR}/token"
+
+# Function to check istio readiness
+istio_health() {
+  cmd=$(curl -s http://localhost:15021/healthz/ready > /dev/null)
+  status=$?
+  return $status
+}
+
+# Ensure we have all files and needed directory write permissions
+if [ ! -d ${VERNEMQ_ETC_DIR} ]; then
+  echo "Configuration directory at ${VERNEMQ_ETC_DIR} does not exist, exiting" >&2
+  exit 1
+fi
+if [ ! -f ${VERNEMQ_VM_ARGS_FILE} ]; then
+  echo "ls -l ${VERNEMQ_ETC_DIR}"
+  ls -l ${VERNEMQ_ETC_DIR}
+  echo "###" >&2
+  echo "### Configuration file ${VERNEMQ_VM_ARGS_FILE} does not exist, exiting" >&2
+  echo "###" >&2
+  exit 1
+fi
+if [ ! -w ${VERNEMQ_VM_ARGS_FILE} ]; then
+  echo "# whoami"
+  whoami
+  echo "# ls -l ${VERNEMQ_ETC_DIR}"
+  ls -l ${VERNEMQ_ETC_DIR}
+  echo "###" >&2
+  echo "### Configuration file ${VERNEMQ_VM_ARGS_FILE} exists, but there are no write permissions! Exiting." >&2
+  echo "###" >&2
+  exit 1
+fi
+if [ ! -s ${VERNEMQ_VM_ARGS_FILE} ]; then
+  echo "ls -l ${VERNEMQ_ETC_DIR}"
+  ls -l ${VERNEMQ_ETC_DIR}
+  echo "###" >&2
+  echo "### Configuration file ${VERNEMQ_VM_ARGS_FILE} is empty! This will not work." >&2
+  echo "### Exiting now." >&2
+  echo "###" >&2
+  exit 1
+fi
 
 # Ensure the Erlang node name is set correctly
 if env | grep "DOCKER_VERNEMQ_NODENAME" -q; then
@@ -28,7 +58,7 @@ if env | grep "DOCKER_VERNEMQ_NODENAME" -q; then
 else
     if [ -n "$DOCKER_VERNEMQ_SWARM" ]; then
         NODENAME=$(hostname -i)
-        sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${NODENAME}/" /etc/vernemq/vm.args
+        sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${NODENAME}/" ${VERNEMQ_VM_ARGS_FILE}
     else
         sed -i.bak -r "s/-name VerneMQ@.+/-name VerneMQ@${IP_ADDRESS}/" ${VERNEMQ_VM_ARGS_FILE}
     fi
@@ -60,6 +90,7 @@ fi
 # If you encounter "SSL certification error (subject name does not match the host name)", you may try to set DOCKER_VERNEMQ_KUBERNETES_INSECURE to "1".
 insecure=""
 if env | grep "DOCKER_VERNEMQ_KUBERNETES_INSECURE" -q; then
+    echo "Using curl with \"--insecure\" argument to access kubernetes API without matching SSL certificate"
     insecure="--insecure"
 fi
 
@@ -72,16 +103,48 @@ if env | grep "DOCKER_VERNEMQ_KUBERNETES_ISTIO_ENABLED" -q; then
     echo "Istio ready"
 fi
 
-if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
-    DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME=${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME:-cluster.local}
+# Function to call a HTTP GET request on the given URL Path, using the hostname
+# of the current k8s cluster name. Usage: "k8sCurlGet /my/path"
+function k8sCurlGet () {
+    local urlPath=$1
+
+    local hostname="kubernetes.default.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}"
+    local certsFile="${SECRETS_KUBERNETES_DIR}/ca.crt"
+    local token=$(cat ${SECRETS_KUBERNETES_DIR}/token)
+    local header="Authorization: Bearer ${token}"
+    local url="https://${hostname}/${urlPath}"
+
+    curl -sS ${insecure} --cacert ${certsFile} -H "${header}" ${url} \
+      || ( echo "### Error on accessing URL ${url}" )
+}
+
+DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME=${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME:-cluster.local}
+if [ -d "${SECRETS_KUBERNETES_DIR}" ] ; then
     # Let's get the namespace if it isn't set
-    DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-$(cat ${NAMESPACE_FILE})}
+    DOCKER_VERNEMQ_KUBERNETES_NAMESPACE=${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE:-$(cat "${SECRETS_KUBERNETES_DIR}/namespace"})}
+
+    # Check the API access that will be needed in the TERM signal handler
+    podResponse=$(k8sCurlGet api/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}/pods/$(hostname) )
+    statefulSetName=$(echo ${podResponse} | jq -r '.metadata.ownerReferences[0].name')
+    statefulSetPath="apis/apps/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}/statefulsets/${statefulSetName}"
+    statefulSetResponse=$(k8sCurlGet ${statefulSetPath} )
+    isCodeForbidden=$(echo ${statefulSetResponse} | jq '.code == 403')
+    if [[ ${isCodeForbidden} == "true" ]]; then
+        echo "Permission error: Cannot access URL ${statefulSetPath}: $(echo ${statefulSetResponse} | jq '.reason,.code,.message')"
+        exit 1
+    else
+        numReplicas=$(echo ${statefulSetResponse} | jq '.status.replicas')
+        echo "Permissions ok: Our pod $(hostname) belongs to StatefulSet ${statefulSetName} with ${numReplicas} replicas"
+    fi
+fi
+
+# Set up kubernetes node discovery
+if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
     # Let's set our nodename correctly
-    AUTHORIZATION_HEADER="Authorization: Bearer $(cat ${TOKEN_FILE})"
-    NAMESPACE_URL="https://kubernetes.default.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}/api/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}"
-    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:-$(curl -sSX GET ${insecure} --cacert ${CA_CRT_FILE} ${NAMESPACE_URL}/pods?labelSelector=${DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR} -H ${AUTHORIZATION_HEADER} \
-        | jq '.items[0].spec.subdomain' | sed 's/"//g' | tr '\n' '\0')}
-    if [ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]; then
+    # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#list-pod-v1-core
+    podList=$(k8sCurlGet "api/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}/pods?labelSelector=${DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR}")
+    VERNEMQ_KUBERNETES_SUBDOMAIN=${DOCKER_VERNEMQ_KUBERNETES_SUBDOMAIN:-$(echo ${podList} | jq '.items[0].spec.subdomain' | tr '\n' '"' | sed 's/"//g')}
+    if [[ $VERNEMQ_KUBERNETES_SUBDOMAIN == "null" ]]; then
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
     else
         VERNEMQ_KUBERNETES_HOSTNAME=${MY_POD_NAME}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}
@@ -89,22 +152,22 @@ if env | grep "DOCKER_VERNEMQ_DISCOVERY_KUBERNETES" -q; then
 
     sed -i.bak -r "s/VerneMQ@.+/VerneMQ@${VERNEMQ_KUBERNETES_HOSTNAME}/" ${VERNEMQ_VM_ARGS_FILE}
     # Hack into K8S DNS resolution (temporarily)
-    kube_pod_names=$(curl -sSX GET $insecure --cacert ${CA_CRT_FILE} ${NAMESPACE_URL}/pods?labelSelector=${DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR} -H ${AUTHORIZATION_HEADER} \
-        | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
+    kube_pod_names=$(echo ${podList} | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
 
     for kube_pod_name in $kube_pod_names; do
-        if [ $kube_pod_name == "null" ]; then
+        if [[ $kube_pod_name == "null" ]]; then
             echo "Kubernetes discovery selected, but no pods found. Maybe we're the first?"
             echo "Anyway, we won't attempt to join any cluster."
             break
         fi
-        if [ $kube_pod_name != $MY_POD_NAME ]; then
-            echo "Will join an existing Kubernetes cluster with discovery node at ${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}"
-            echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}')\"" >> ${VERNEMQ_VM_ARGS_FILE}
+        if [[ $kube_pod_name != $MY_POD_NAME ]]; then
+            discoveryHostname="${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}"
+            echo "Will join an existing Kubernetes cluster with discovery node at ${discoveryHostname}"
+            echo "-eval \"vmq_server_cmd:node_join('VerneMQ@${discoveryHostname}')\"" >> ${VERNEMQ_VM_ARGS_FILE}
             echo "Did I previously leave the cluster? If so, purging old state."
-            curl -fsSL http://${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}:8888/status.json >/dev/null 2>&1 ||
+            curl -fsSL http://${discoveryHostname}:8888/status.json >/dev/null 2>&1 ||
                 (echo "Can't download status.json, better to exit now" && exit 1)
-            curl -fsSL http://${kube_pod_name}.${VERNEMQ_KUBERNETES_SUBDOMAIN}.${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}:8888/status.json | grep -q ${VERNEMQ_KUBERNETES_HOSTNAME} ||
+            curl -fsSL http://${discoveryHostname}:8888/status.json | grep -q ${VERNEMQ_KUBERNETES_HOSTNAME} ||
                 (echo "Cluster doesn't know about me, this means I've left previously. Purging old state..." && rm -rf /vernemq/data/*)
             break
         fi
@@ -182,7 +245,7 @@ siguser1_handler() {
 # SIGTERM-handler
 sigterm_handler() {
     if [ $pid -ne 0 ]; then
-        if [ -d "${SECRETS_KUBERNETES_DIR}" -a -f "${TOKEN_FILE}" ] ; then
+        if [ -d "${SECRETS_KUBERNETES_DIR}" ] ; then
             # this will stop the VerneMQ process, but first drain the node from all existing client sessions (-k)
             if [ -n "$VERNEMQ_KUBERNETES_HOSTNAME" ]; then
                 terminating_node_name=VerneMQ@$VERNEMQ_KUBERNETES_HOSTNAME
@@ -191,28 +254,38 @@ sigterm_handler() {
             else
                 terminating_node_name=VerneMQ@$IP_ADDRESS
             fi
-            AUTHORIZATION_HEADER="Authorization: Bearer $(cat ${TOKEN_FILE})"
-            NAMESPACE_URL="https://kubernetes.default.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}/api/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}"
-            kube_pod_names=$(curl -sSX GET ${insecure} --cacert ${CA_CRT_FILE} -H ${AUTHORIZATION_HEADER} ${NAMESPACE_URL}/pods?labelSelector=${DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR} \
-                | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
-            if [ $kube_pod_names == $MY_POD_NAME ]; then
-                echo "I'm the only pod remaining, not performing leave and state purge."
+            podList=$(k8sCurlGet "api/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}/pods?labelSelector=${DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR}")
+            kube_pod_names=$(echo ${podList} | jq '.items[].spec.hostname' | sed 's/"//g' | tr '\n' ' ')
+            if [ "$kube_pod_names" = "$MY_POD_NAME" ]; then
+                echo "I'm the only pod remaining. Not performing leave and/or state purge."
                 /vernemq/bin/vmq-admin node stop >/dev/null
             else
-                # Lookup the NAMESPACE from the file again (maybe this should be changed into the DOCKER_VERNEMQ_KUBERNETES_NAMESPACE variable?)
-                NAMESPACE=$(cat ${NAMESPACE_FILE})
-                NAMESPACE_URL="https://kubernetes.default.svc.${DOCKER_VERNEMQ_KUBERNETES_CLUSTER_NAME}/api/v1/namespaces/${NAMESPACE}"
-                statefulset=$(curl -sSX GET --cacert ${CA_CRT_FILE} -H ${AUTHORIZATION_HEADER} \
-                    ${NAMESPACE_URL}/pods/$(hostname) | jq -r '.metadata.ownerReferences[0].name')
+                # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#read-pod-v1-core
+                podResponse=$(k8sCurlGet api/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}/pods/$(hostname) )
+                statefulSetName=$(echo ${podResponse} | jq -r '.metadata.ownerReferences[0].name')
 
-                reschedule=$(curl -sSX GET --cacert ${CA_CRT_FILE} -H ${AUTHORIZATION_HEADER} \
-                    ${NAMESPACE_URL}/statefulsets/${statefulset} | jq '.status.replicas == .status.currentReplicas')
+                # https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#-strong-read-operations-statefulset-v1-apps-strong-
+                statefulSetResponse=$(k8sCurlGet "apis/apps/v1/namespaces/${DOCKER_VERNEMQ_KUBERNETES_NAMESPACE}/statefulsets/${statefulSetName}" )
 
-                if [[ ${reschedule} == "true" ]]; then
-                    echo "Reschedule is true, not leaving the cluster"
-                    /vernemq/bin/vmq-admin node stop >/dev/null
+                isCodeForbidden=$(echo ${statefulSetResponse} | jq '.code == 403')
+                if [[ ${isCodeForbidden} == "true" ]]; then
+                    echo "Permission error: Cannot access URL ${statefulSetPath}: $(echo ${statefulSetResponse} | jq '.reason,.code,.message')"
+                fi
+
+                reschedule=$(echo ${statefulSetResponse} | jq '.status.replicas == .status.readyReplicas')
+                scaled_down=$(echo ${statefulSetResponse} | jq '.status.currentReplicas == .status.updatedReplicas')
+
+                if [[ $reschedule == "true" ]]; then
+                    # Perhaps is an scale down?
+                    if [[ $scaled_down == "true" ]]; then
+                      echo "Seems that this is a scale down scenario. Leaving cluster."
+                      /vernemq/bin/vmq-admin cluster leave node=${terminating_node_name} -k && rm -rf /vernemq/data/*
+                    else
+                      echo "Reschedule is true. Not leaving the cluster."
+                      /vernemq/bin/vmq-admin node stop >/dev/null
+                    fi
                 else
-                    echo "Reschedule is false, leaving the cluster"
+                    echo "Reschedule is false. Leaving the cluster."
                     /vernemq/bin/vmq-admin cluster leave node=${terminating_node_name} -k && rm -rf /vernemq/data/*
                 fi
             fi
@@ -227,6 +300,16 @@ sigterm_handler() {
     fi
     exit 143; # 128 + 15 -- SIGTERM
 }
+
+if [ ! -s ${VERNEMQ_VM_ARGS_FILE} ]; then
+  echo "ls -l ${VERNEMQ_ETC_DIR}"
+  ls -l ${VERNEMQ_ETC_DIR}
+  echo "###" >&2
+  echo "### Configuration file ${VERNEMQ_VM_ARGS_FILE} is empty! This will not work." >&2
+  echo "### Exiting now." >&2
+  echo "###" >&2
+  exit 1
+fi
 
 # Setup OS signal handlers
 trap 'siguser1_handler' SIGUSR1


### PR DESCRIPTION
Added more sanity checks about potentially missing file or directory permissions that were observed on k8s with various storage providers, which unexpectedly come with too little write permissions. Checking for those conditions and quickly abort with clear error messages significantly makes life easier if those conditions occur.

Moved most curl-commands into a common function to make code more readable.

The k8s API calls that are used in the SIGTERM handler will be checked during startup to clarify whether we have proper permissions and don't accidentally run into this at shutdown. It was observed that those permissions have not (yet) been granted, causing the SIGTERM handler to fail, which breaks the cluster apart.

Fixing shutdown at k8s that was not properly checking the intended change in number of replicas.