### PR TITLE
#317 bumps helm chart version to 1.6.13

### DIFF
--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.12.3
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.6.12-1
+version: 1.6.13
 
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png


### PR DESCRIPTION
I forgot to bump the version in my fix for #317.

@ioolkos Can you make a new release for this version? We need the missing sts permission.