### PR TITLE
adds services that exposes api through k8s service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN curl -L https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSIO
 # 8080  MQTT WebSockets
 # 44053 VerneMQ Message Distribution
 # 4369  EPMD - Erlang Port Mapper Daemon
-# 8888  Prometheus Metrics
+# 8888  Health, API, Prometheus Metrics
 # 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109  Specific Distributed Erlang Port Range
 
 EXPOSE 1883 8883 8080 44053 4369 8888 \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -30,7 +30,7 @@ RUN curl -L https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSIO
 # 8080  MQTT WebSockets
 # 44053 VerneMQ Message Distribution
 # 4369  EPMD - Erlang Port Mapper Daemon
-# 8888  Prometheus Metrics
+# 8888  Health, API, Prometheus Metrics
 # 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109  Specific Distributed Erlang Port Range
 
 EXPOSE 1883 8883 8080 44053 4369 8888 \

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.12.3
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.6.12-1
+version: 1.7.0
 
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/templates/api-service.yaml
+++ b/helm/vernemq/templates/api-service.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.service.api.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "vernemq.fullname" . }}-api
+  labels:
+    app.kubernetes.io/name: {{ include "vernemq.name" . }}
+    helm.sh/chart: {{ include "vernemq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- if .Values.service.labels }}
+    {{ toYaml .Values.service.labels | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+{{- if .Values.service.api.sessionAffinity }}
+  sessionAffinity: {{ .Values.service.api.sessionAffinity }}
+  {{- if .Values.service.api.sessionAffinityConfig }}
+  sessionAffinityConfig:
+    {{ toYaml .Values.service.api.sessionAffinityConfig | nindent 4 }}
+  {{- end -}}
+{{- end }}
+  ports:
+    - port: {{ .Values.service.api.port }}
+      targetPort: api
+      name: api
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.api.nodePort }}
+      {{- end }}
+  selector:
+    app.kubernetes.io/name: {{ include "vernemq.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/helm/vernemq/templates/headless-service.yaml
+++ b/helm/vernemq/templates/headless-service.yaml
@@ -14,7 +14,7 @@ spec:
     port: 4369
   - name: metrics
     port: 8888
-    targetPort: prometheus
+    targetPort: api
   selector:
     app.kubernetes.io/name: {{ include "vernemq.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -57,7 +57,7 @@ spec:
             - containerPort: 8443
               name: wss
             - containerPort: 8888
-              name: prometheus
+              name: api
             {{- range tuple 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109 }}
             - containerPort: {{ . }}
             {{- end }}
@@ -95,7 +95,7 @@ spec:
           livenessProbe:
             httpGet:
               path: /health
-              port: prometheus
+              port: api
               scheme: HTTP
             initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.statefulset.livenessProbe.periodSeconds }}
@@ -105,7 +105,7 @@ spec:
           readinessProbe:
             httpGet:
               path: /health
-              port: prometheus
+              port: api
               scheme: HTTP
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -51,6 +51,10 @@ service:
     port: 8443
     # This is the port used by nodes to expose the service
     nodePort: 8443
+  api:
+    enabled: false
+    port: 8888
+    nodePort: 38888
   annotations: {}
   labels: {}
   


### PR DESCRIPTION
This MR adds an additional service `vernemq-api` that exposes the API port (default `8888`).

It adds an additional service instead of exposing it through the existing one so that the MQTT port can be exposed outside the cluster via service type `LoadBalancer` while keeping the vmq API internal.

Currently this port is only exposed via the headless service.
