### PR TITLE
update headless service to expose more ports

### DIFF
--- a/helm/vernemq/templates/headless-service.yaml
+++ b/helm/vernemq/templates/headless-service.yaml
@@ -15,6 +15,18 @@ spec:
   - name: metrics
     port: 8888
     targetPort: api
+  - name: mqtt
+    port: {{ .Values.service.mqtt.port }}
+    targetPort: mqtt
+  - name: mqtts
+    port: {{ .Values.service.mqtts.port }}
+    targetPort: mqtts
+  - name: ws 
+    port: {{ .Values.service.ws.port }}
+    targetPort: ws
+  - name: wss
+    port: {{ .Values.service.wss.port }}
+    targetPort: wss
   selector:
     app.kubernetes.io/name: {{ include "vernemq.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
Use case here is for an internal ingest service to be able to consume messages from a specific pod. We are attaching an ingest service pod from a stateful set to each vernemq set so there is a 1:1 ratio for our ingest service to the cluster. This gives max ha and load balancing as messages don't need to get redirected internally and each mqtt pod has its own ingest service pod. In order to do this the ingest service needs to directly access each mqtt pod via `<pod-name>-<ordinal>.<service-name>.<namespace>.svc.cluster.local` dns entry. Our ingest service is also a statefulset with the same number of replicas that then gets a array of host dns entries along with an index field populated via `HOST_INDEX : fieldRef(v1:metadata.annotations['spec.pod.beta.kubernetes.io/statefulset-index'])` to allow each pod to connect. 

We can't create another headless service as the builtin headless service name is listed in the stateful set spec. Another solution may be to allow the user to provide a headless service name to override it. I think it would be better to just make this more configurable. Not sure if this should have its own config options or if there is a better way to make this optional -  maybe just an "extraPort" array option in the yaml that allows the user to specify and configure what they would like to expose. What are your thoughts? 