### PR TITLE
Added explicit version and kind to volume claim template 

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -177,7 +177,9 @@ spec:
       {{- end }}
 {{- if .Values.persistentVolume.enabled }}
   volumeClaimTemplates:
-    - metadata:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      metadata:
         name: data
         annotations:
         {{- range $key, $value := .Values.persistentVolume.annotations }}


### PR DESCRIPTION
This PR only adds explicit `version` and `kind` information to the volume claim template when persistence is used. While this does not change any behavior for the chart itself this will prevent a few problems with gitops based workflows (see https://github.com/kubernetes/website/pull/38981 and https://github.com/argoproj/argo-cd/issues/11143).
This change shouldn't cause any behavior change is only for the convenience of users of gitops based workflows.