### PR TITLE
Pod disruption budgets are now policy/v1

### DIFF
--- a/helm/vernemq/templates/poddisruptionbudget.yaml
+++ b/helm/vernemq/templates/poddisruptionbudget.yaml
@@ -1,5 +1,5 @@
 {{ if and .Values.pdb .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "vernemq.fullname" . }}


### PR DESCRIPTION
As per https://kubernetes.io/docs/tasks/run-application/configure-pdb/#protecting-an-application-with-a-poddisruptionbudget

PodDisruptionBudget are now in policy/v1 so the beta will not work on new clusters > 1.21