### PR TITLE
Add Index page to VerneMQ HELM charts and propose subdomain

### DIFF
--- a/.github/workflows/sync-helm-repo.yaml
+++ b/.github/workflows/sync-helm-repo.yaml
@@ -1,0 +1,32 @@
+on:
+  push:
+    branches:
+      - "master"
+    paths:
+      - "CNAME"
+      - "helm/README.md"
+
+permissions: {}
+
+jobs:
+  build:
+    permissions:
+      contents: write # for git push
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          cp -f helm/README.md ${{ runner.temp }}/README.md
+          cp -f CNAME ${{ runner.temp }}/CNAME
+      - uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - run: |
+          cp -f ${{ runner.temp }}/README.md .
+          cp -f ${{ runner.temp }}/CNAME .
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+          git add CNAME README.md
+          git commit --signoff -m "Sync repo website from main"
+          git push

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+charts.vernemq.com

--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -1,4 +1,6 @@
-# VerneMQ
+# VerneMQ Kubernetes Helm Charts
+
+This is the official Helm Charts repository for installing VerneMQ on Kubernetes.
 
 [VerneMQ](https://vernemq.com/) is a high-performance, distributed MQTT message broker. It scales
 horizontally and vertically on commodity hardware to support a high number of
@@ -20,7 +22,19 @@ This chart bootstraps a [VerneMQ](https://vernemq.com/) deployment on a [Kuberne
 
 ## Prerequisites
 
-- Kubernetes 1.9, or 1.5 with Beta features enabled
+- Kubernetes 1.9, or 1.5 with Beta features enabled.
+- [Helm](https://helm.sh/) must be installed to use the charts. Please refer to Helm’s [documentation](https://helm.sh/docs/intro/install/) to get started.
+
+## Adding this Helm repo
+
+Once Helm is set up properly, add the VerneMQ repo as follows:
+
+```bash
+$ helm repo add vernemq https://charts.vernemq.com
+$ helm repo update
+```
+
+You can then run `helm search repo vernemq` to see the available charts.
 
 ## Installing the Chart
 
@@ -115,7 +129,7 @@ Parameter | Description | Default
 `certificates.key` | String (not base64 encoded) containing the listener private key in PEM format | `nil`
 `certificates.ca` | String (not base64 encoded) containing the CA certificate for validating client certs | `nil`
 `certificates.secret.labels` | additional labels for the created secret containing certificates and keys | `nil`
-`certificates.secret.annotations` | additional labels for the created secret containing certificates and keys | `nil` 
+`certificates.secret.annotations` | additional labels for the created secret containing certificates and keys | `nil`
 `acl.enabled` | whether acls should be applied | `false`
 `acl.content` | content of the acl file | `topic #`
 `acl.labels` | additional labels on the acl configmap | `{}`
@@ -247,3 +261,8 @@ additionalEnv:
 ```
 
 > **Tip**: Cert-Manager includes both CA and TLS certificate in the `tls.crt` file.
+
+## Seeking help
+
+If you run into an issue, bug or have a question, please open Github
+issues in the [docker-vernemq](https://github.com/vernemq/docker-vernemq) repository.


### PR DESCRIPTION
Improves the Index page for the Helm charts to make them more discoverable on google and other SE. Proposes a subdomain name for the site but that requires DNS setup following https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/managing-a-custom-domain-for-your-github-pages-site, will this be possible @ioolkos ?

