### PR TITLE
fix(acl): configmap was hardcoded in the sts

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -198,7 +198,7 @@ spec:
         {{- if .Values.acl.enabled }}
         - name: vernemq-acl
           configMap:
-            name:: {{ include "vernemq.fullname" . }}-acl
+            name: {{ include "vernemq.fullname" . }}-acl
       {{- end }}
       {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -198,7 +198,7 @@ spec:
         {{- if .Values.acl.enabled }}
         - name: vernemq-acl
           configMap:
-            name: vernemq-acl
+            name:: {{ include "vernemq.fullname" . }}-acl
       {{- end }}
       {{- if .Values.extraVolumes }}
         {{- toYaml .Values.extraVolumes | nindent 8 }}


### PR DESCRIPTION
The configmap name is generated based upon `vernemq.fullname` but in the `StatefulSet` the volumeMount is linked to a hardcoded configmap name value.

This does not work if the release name is not exactly `vernemq`