### PR TITLE
Add an action for linting and releasing helm chart

### DIFF
--- a/.github/workflows/helm-chart-workflow.yaml
+++ b/.github/workflows/helm-chart-workflow.yaml
@@ -1,0 +1,52 @@
+---
+name: Lint and release the helm chart
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.12.1
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.4.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs helm --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }} --validate-maintainers=false --chart-dirs helm
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Release charts
+        if: github.ref == ${{ github.event.repository.default_branch }}
+        uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: helm
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-chart-workflow.yaml
+++ b/.github/workflows/helm-chart-workflow.yaml
@@ -1,8 +1,6 @@
 ---
 name: Lint and release the helm chart
-on:
-  pull_request:
-  push:
+on: push
 
 jobs:
   lint-test:

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 appVersion: 1.13.0
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 1.9.0
+version: 1.9.1
 
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -58,7 +58,7 @@ service:
     annotations: {}
   annotations: {}
   labels: {}
-  
+
 
 ## Ingress can optionally be applied when enabling the MQTT websocket service
 ## This allows for an ingress controller to route web ports and arbitrary hostnames
@@ -83,7 +83,6 @@ ingress:
   paths:
     - path: /
       pathType: ImplementationSpecific
-      
 
   ## TLS configuration for ingress
   ## Secret must be manually created in the namespace


### PR DESCRIPTION
Hi,

I've added a GitHub action that is linting helm chart on each pushed commit and releasing a new version helm chart automatically on each new push to the `master` branch.

The linter job is checking whether the chart is changed, and in case it is, the linter expects the versions to be bumped. That means that all the changes to chart will be delivered to its users right away.

The releaser action is adding the helm chart archive to github releases and creating an index file in the branch that is used as a github pages branch (currently, hardcoded to gh-pages)

Since it's rather a worklfow change, I wouldn't expect you to actually merge it, cause  you probably have you own workflow, and it's something new to maintain, but I think that many users of you chart would benefit from having an ability to get latest changes when they are merged to `master` instead of waiting for the new release. So if you consider merging it I can support this action for a time being

Thanks
