### PR TITLE
fix: allow LoadBalancer type for api service

### DIFF
--- a/helm/vernemq/templates/api-service.yaml
+++ b/helm/vernemq/templates/api-service.yaml
@@ -16,10 +16,23 @@ metadata:
     {{ toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- if (or (eq .Values.service.api.type "ClusterIP") (empty .Values.service.type)) }}
   type: ClusterIP
-  {{- if .Values.service.clusterIP }}
-  clusterIP: {{ .Values.service.clusterIP }}
+  {{- if .Values.service.api.clusterIP }}
+  clusterIP: {{ .Values.service.api.clusterIP }}
   {{- end }}
+{{- else if eq .Values.service.api.type "LoadBalancer" }}
+  type: {{ .Values.service.api.type }}
+  {{- if .Values.service.api.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.api.loadBalancerIP }}
+  {{- end }}
+  {{- if .Values.service.api.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{ toYaml .Values.service.api.loadBalancerSourceRanges | nindent 4 }}
+  {{- end -}}
+{{- else }}
+  type: {{ .Values.service.api.type }}
+{{- end }}
 {{- if .Values.service.api.sessionAffinity }}
   sessionAffinity: {{ .Values.service.api.sessionAffinity }}
   {{- if .Values.service.api.sessionAffinityConfig }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -53,6 +53,7 @@ service:
     nodePort: 8443
   api:
     enabled: false
+    type: ClusterIP
     port: 8888
     nodePort: 38888
     annotations: {}


### PR DESCRIPTION
The goal of this PR is to mimic how we allow different Service types for the isolated API service, rather than forcing a ClusterIP type.