### PR TITLE
Helm chart: container securityContext

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -31,7 +31,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       {{- if .Values.statefulset.podLabels }}
         {{ toYaml .Values.statefulset.podLabels | nindent 8 }}
-      {{- end }}        
+      {{- end }}
       {{- with .Values.statefulset.podAnnotations }}
       annotations:
         {{ toYaml . | nindent 8 }}
@@ -145,6 +145,10 @@ spec:
           {{- end }}
           {{- with .Values.statefulset.lifecycle }}
           lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
     {{- with .Values.nodeSelector }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -120,10 +120,16 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 podAntiAffinity: soft
 
+# Security context (for the pods)
 securityContext:
   runAsUser: 10000
   runAsGroup: 10000
   fsGroup: 10000
+
+# Security context (for the containers, uncomment if needed; default is no specific container-level security context)
+# containerSecurityContext:
+  # privileged: ...
+  # ...
 
 ## If RBAC is enabled on the cluster,VerneMQ needs a service account
 ## with permissisions sufficient to list pods


### PR DESCRIPTION
Make the kubernetes securityContext configurable on the container level (in addition to the already configurable securityContext on the pod level).

Fixes: #375