### PR TITLE
Helm chart: image pull secrets

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -39,6 +39,12 @@ spec:
     spec:
       serviceAccountName: {{ include "vernemq.serviceAccountName" . }}
       terminationGracePeriodSeconds: {{ .Values.statefulset.terminationGracePeriodSeconds }}
+      {{- with .Values.statefulset.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range . }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -214,6 +214,8 @@ statefulset:
   labels: {}
   podLabels: {}
   lifecycle: {}
+  imagePullSecrets:
+#    - "my-image-pull-secret"
 
 pdb:
   enabled: false


### PR DESCRIPTION
Make the image pull secrets configurable for the stateful set rendered by the helm chart.

Fixes: #383