### PR TITLE
extend wait before configuring api key

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -400,8 +400,12 @@ if [ $start_join_cluster  -eq 1 ]; then
     mkdir -p /var/log/vernemq/log
     join_cluster > /var/log/vernemq/log/join_cluster.log &
 fi
+
 if [ -n "$API_KEY" ]; then
-  sleep 10 && echo "Adding API_KEY..." && /vernemq/bin/vmq-admin api-key add key="${API_KEY:-DEFAULT}"
+  sleep 60
+  echo "Adding API_KEY..."
+  vmq-admin api-key add key="${API_KEY}"
   vmq-admin api-key show
 fi
+
 wait $pid


### PR DESCRIPTION
We were not able to get a consistently configured API key in a clustered setup with a wait of 10 seconds, 60 seems to work better. Ideally we would like not to have a static wait, but we were not able to figure out what condition has to be true to be able to set the API key.

Also to reduce risk, we removed the `DEFAULT` for the API key. The whole expression is guarded by `-n` but this might pose a risk during refactoring and we would prefer an error over setting a default API key that might open an attack vector.