### PR TITLE
feat(helm): configurable scrape interval for ServiceMonitor

### DIFF
--- a/helm/vernemq/README.md
+++ b/helm/vernemq/README.md
@@ -107,6 +107,7 @@ Parameter | Description | Default
 `statefulset.updateStrategy` | Statefulset updateStrategy | `RollingUpdate`
 `statefulset.lifecycle` | Statefulset lifecycle hooks | `{}`
 `serviceMonitor.create` | whether to create a ServiceMonitor for Prometheus Operator | `false`
+`serviceMonitor.interval` | the scrape interval for the ServiceMonitor for Prometheus Operator | `30s`
 `serviceMonitor.labels` | whether to add more labels to ServiceMonitor for Prometheus Operator | `{}`
 `pdb.enabled` | whether to create a Pod Disruption Budget | `false`
 `pdb.minAvailable` | PDB (min available) for the cluster | `1`

--- a/helm/vernemq/templates/servicemonitor.yaml
+++ b/helm/vernemq/templates/servicemonitor.yaml
@@ -13,7 +13,7 @@ metadata:
     {{- end }}
 spec:
   endpoints:
-  - interval: 30s
+  - interval: {{ .Values.serviceMonitor.interval }}
     port: metrics
     path: /metrics
   selector:

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -15,6 +15,7 @@ fullnameOverride: ""
 
 serviceMonitor:
   create: false
+  interval: 30s
   labels: {}
 
 service:


### PR DESCRIPTION
This enables a configurable scrape interval when using the ServiceMonitor for Prometheus Operator.

Defaults to 30s as per existing behaviour.