### PR TITLE
Helm chart: Fix API-service type check for NodePort

### DIFF
--- a/helm/vernemq/templates/api-service.yaml
+++ b/helm/vernemq/templates/api-service.yaml
@@ -44,7 +44,7 @@ spec:
     - port: {{ .Values.service.api.port }}
       targetPort: api
       name: api
-      {{- if eq .Values.service.type "NodePort" }}
+      {{- if eq .Values.service.api.type "NodePort" }}
       nodePort: {{ .Values.service.api.nodePort }}
       {{- end }}
   selector:


### PR DESCRIPTION
The template for api-service was falsely checking the non-API service types to add a nodePort, leading to an invalid configuration.