### PR TITLE
fix(vernemq.sh): remove show api-key

### DIFF
--- a/bin/vernemq.sh
+++ b/bin/vernemq.sh
@@ -405,7 +405,6 @@ if [ -n "$API_KEY" ]; then
   sleep 60
   echo "Adding API_KEY..."
   vmq-admin api-key add key="${API_KEY}"
-  vmq-admin api-key show
 fi
 
 wait $pid


### PR DESCRIPTION
The API Key is being shown in the stdout when launching the container.

This is a security risk, as anyone with access to a central logging system may see the APIKEY.