### PR TITLE
fix(statefulset): indentation is now correct

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -70,7 +70,7 @@ spec:
             {{- if .Values.headlessService.customPorts }}
             {{- range .Values.headlessService.customPorts }}
             - containerPort: {{ .port }}
-            name: {{ .name }}
+              name: {{ .name }}
             {{- end }}
             {{- end }}
             {{- range tuple 9100 9101 9102 9103 9104 9105 9106 9107 9108 9109 }}
@@ -248,5 +248,5 @@ spec:
       {{- end }}
       {{- end }}
 {{- else }}
-        - name: data
+      - name: data
 {{- end }}


### PR DESCRIPTION
When trying to use custom ports I was faced with the following error:

```
Error: UPGRADE FAILED: YAML parse error on vernemq/templates/statefulset.yaml: error converting YAML to JSON: yaml: line 49: did not find expected '-' indicator
```

So that is now fixed on line 73.
When looking at the problem I noticed another possible indentation issue in line 251.