### PR TITLE
Refactor vernemq.sh start script, remove most of K8s logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /vernemq
 ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
     DOCKER_VERNEMQ_LOG__CONSOLE=console \
     PATH="/vernemq/bin:$PATH" \
-    VERNEMQ_VERSION="2.0.1"
+    VERNEMQ_VERSION="2.1.1"
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq
 COPY --chown=10000:10000 bin/join_cluster.sh /usr/sbin/join_cluster
 COPY --chown=10000:10000 files/vm.args /vernemq/etc/vm.args

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -10,7 +10,7 @@ RUN apk --no-cache --update --available upgrade && \
 ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
     DOCKER_VERNEMQ_LOG__CONSOLE=console \
     PATH="/vernemq/bin:$PATH" \
-    VERNEMQ_VERSION="2.0.1"
+    VERNEMQ_VERSION="2.1.1"
 WORKDIR /vernemq
 
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq

--- a/helm/vernemq/Chart.yaml
+++ b/helm/vernemq/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
-appVersion: 2.0.1
+appVersion: 2.1.1
 description: VerneMQ is a high-performance, distributed MQTT message broker
 name: vernemq
-version: 2.0.1
+version: 2.1.1
 
 icon: http://www.stickpng.com/assets/thumbs/58482b21cef1014c0b5e4a24.png

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: vernemq/vernemq
-  tag: 2.0.1-alpine
+  tag: 2.1.1-alpine
 
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
 Changes to the VerneMQ (vernemq.sh) start script:
 
 Don't try to be smart on Kubernetes. We therefore remove the logic handling Pod termination, and
 trying to find out whether a VerneMQ should just stop or leave the cluster. We will now stop VerneMQ when
 the Pod terminates. We will never do a cluster leave and will never rm the data directories automatically.
 (except when using Docker Swarm, where the old behaviour is kept for now).
 We will still try to get a Discovery node on Kubernetes by getting the pod list, and try to auto-join. 
 
 The consequence is that you will now need persistent volume claims for VerneMQ nodes on Kubernetes.
 
 Note: if you end up having a cluster node that you do not want in the cluster, you can make it leave using
 the `vmq-admin cluster leave` command from an arbitrary cluster node.