### PR TITLE
feat(statefulset): add support for exec and tcpSocket readinessProbe

### DIFF
--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -126,10 +126,18 @@ spec:
             successThreshold: {{ .Values.statefulset.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
           readinessProbe:
+          {{- if .Values.statefulset.readinessProbe.exec }}
+            exec:
+              command: {{ toYaml .Values.statefulset.readinessProbe.exec.command | nindent 14 }}
+          {{- else if .Values.statefulset.readinessProbe.tcpSocket }}
+            tcpSocket:
+              port: {{ .Values.statefulset.readinessProbe.tcpSocket.port }}
+          {{- else }}
             httpGet:
-              path: /health/ping
-              port: api
-              scheme: HTTP
+              path: {{ .Values.statefulset.readinessProbe.httpGet.path }}
+              port: {{ .Values.statefulset.readinessProbe.httpGet.port }}
+              scheme: {{ .Values.statefulset.readinessProbe.httpGet.scheme }}
+          {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.statefulset.readinessProbe.timeoutSeconds }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -212,6 +212,10 @@ statefulset:
     successThreshold: 1
     failureThreshold: 3
   readinessProbe:
+    httpGet:
+      path: /health/ping
+      port: api
+      scheme: HTTP
     initialDelaySeconds: 90
     periodSeconds: 10
     timeoutSeconds: 5


### PR DESCRIPTION
Fixes https://github.com/vernemq/docker-vernemq/issues/410