### PR TITLE
Set execute permissions for startup scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
     VERNEMQ_VERSION="2.1.1"
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq
 COPY --chown=10000:10000 bin/join_cluster.sh /usr/sbin/join_cluster
+RUN chmod +x /usr/sbin/start_vernemq /usr/sbin/join_cluster
 COPY --chown=10000:10000 files/vm.args /vernemq/etc/vm.args
 
 # Note that the following copies a binary package under EULA (requiring a paid subscription).


### PR DESCRIPTION
Add execute permissions to start_vernemq and join_cluster scripts

Otherwise, the following error will be reported at startup

`docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "start_vernemq": executable file not found in $PATH`