### PR TITLE
feat(docker): add build arg VERNEMQ_TARBALL_URL for custom binary distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,15 +13,19 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
     DOCKER_VERNEMQ_LOG__CONSOLE=console \
     PATH="/vernemq/bin:$PATH" \
     VERNEMQ_VERSION="2.1.1"
+
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq
 COPY --chown=10000:10000 bin/join_cluster.sh /usr/sbin/join_cluster
 COPY --chown=10000:10000 files/vm.args /vernemq/etc/vm.args
 
-# Note that the following copies a binary package under EULA (requiring a paid subscription).
-RUN ARCH=$(uname -m | sed -e 's/aarch64/arm64/') && \
-    curl -L https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSION/vernemq-$VERNEMQ_VERSION.bookworm.$ARCH.tar.gz -o /tmp/vernemq-$VERNEMQ_VERSION.bookworm.tar.gz && \
-    tar -xzvf /tmp/vernemq-$VERNEMQ_VERSION.bookworm.tar.gz && \
-    rm /tmp/vernemq-$VERNEMQ_VERSION.bookworm.tar.gz && \
+# The default VERNEMQ_TARBALL_URL points to the official VerneMQ binary
+# package, which is distributed under a EULA: commercial use requires a paid
+# subscription.
+ARG TARGETARCH
+ARG VERNEMQ_TARBALL_URL="https://github.com/vernemq/vernemq/releases/download/${VERNEMQ_VERSION}/vernemq-${VERNEMQ_VERSION}.bookworm.${TARGETARCH/aarch64/arm64}.tar.gz"
+ADD --unpack=false ${VERNEMQ_TARBALL_URL} /tmp/vernemq.tar.gz
+RUN tar -xzvf /tmp/vernemq.tar.gz && \
+    rm /tmp/vernemq.tar.gz && \
     chown -R 10000:10000 /vernemq && \
     ln -s /vernemq/etc /etc/vernemq && \
     ln -s /vernemq/data /var/lib/vernemq && \

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -11,18 +11,19 @@ ENV DOCKER_VERNEMQ_KUBERNETES_LABEL_SELECTOR="app=vernemq" \
     DOCKER_VERNEMQ_LOG__CONSOLE=console \
     PATH="/vernemq/bin:$PATH" \
     VERNEMQ_VERSION="2.1.1"
-WORKDIR /vernemq
 
 COPY --chown=10000:10000 bin/vernemq.sh /usr/sbin/start_vernemq
 COPY --chown=10000:10000 bin/join_cluster.sh /usr/sbin/join_cluster
 COPY --chown=10000:10000 files/vm.args /vernemq/etc/vm.args
 
-# Note that the following copies a binary package under EULA (requiring a paid subscription).
-RUN ARCH=$(uname -m | sed -e 's/aarch64/arm64/') && \
-    echo $ARCH && \
-    curl -L https://github.com/vernemq/vernemq/releases/download/$VERNEMQ_VERSION/vernemq-$VERNEMQ_VERSION.alpine.$ARCH.tar.gz -o /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
-    tar -xzvf /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
-    rm /tmp/vernemq-$VERNEMQ_VERSION.alpine.tar.gz && \
+# The default VERNEMQ_TARBALL_URL points to the official VerneMQ binary
+# package, which is distributed under a EULA: commercial use requires a paid
+# subscription.
+ARG TARGETARCH
+ARG VERNEMQ_TARBALL_URL="https://github.com/vernemq/vernemq/releases/download/${VERNEMQ_VERSION}/vernemq-${VERNEMQ_VERSION}.bookworm.${TARGETARCH/aarch64/arm64}.tar.gz"
+ADD --unpack=false ${VERNEMQ_TARBALL_URL} /tmp/vernemq.tar.gz
+RUN tar -xzvf /tmp/vernemq.tar.gz && \
+    rm /tmp/vernemq.tar.gz && \
     chown -R 10000:10000 /vernemq && \
     ln -s /vernemq/etc /etc/vernemq && \
     ln -s /vernemq/data /var/lib/vernemq && \

--- a/README.md
+++ b/README.md
@@ -19,8 +19,17 @@ User License Agreement](https://vernemq.com/end-user-license-agreement). You can
 read how to accept the VerneMQ EULA
 [here](https://docs.vernemq.com/installation/accepting-the-vernemq-eula).
 
-**NOTE 2 (TL:DR)**:
-To use the binary Docker packages (that is, the official packages from Docker Hub) or the VerneMQ binary Linux packages commercially and legally, you need a paid subscription. Accepting the EULA is your promise to do that. To avoid a subscription, you need to clone this repository and build and host your own Dockerfiles/-images.
+**NOTE 2 (TL:DR)**: To use the binary Docker packages (that is, the official
+packages from Docker Hub) or the VerneMQ binary Linux packages commercially and
+legally, you need a paid subscription. Accepting the EULA is your promise to do
+that. To avoid a subscription, you need to clone this repository and build and
+host your own VerneMQ binary package and Dockerfiles/-images.
+
+The Dockerfiles download the official binary package (under EULA) by default. To
+build an image from a self-built VerneMQ tarball instead, override the
+`VERNEMQ_TARBALL_URL` build argument:
+
+    docker build --build-arg VERNEMQ_TARBALL_URL='https://example.com/vernemq-2.1.1.bookworm.amd64.tar.gz' .
 
 ### 2. Using [Helm](https://helm.sh/) to deploy on [Kubernetes](https://kubernetes.io/)
 


### PR DESCRIPTION
To be EULA compliant a own VerneMQ build has to be used. This feature was introduced in https://github.com/vernemq/docker-vernemq/pull/83 but later removed in https://github.com/vernemq/docker-vernemq/pull/172. This PR adds docker build arguments `VERNEMQ_TARBALL_URL` that allow users to configure an own binary package.

In addition the curl download has been replaced with the docker native `ADD` command which resolves urls, and caches the downloaded binary. This even allows to use local builds without using an http download by setting `VERNEMQ_TARBALL_URL` to an local file.

The architecture of the download is evaluated by dockers `TARGETARCH` argument. This can be used to build for multiple plattforms i.e. by setting `--platform linux/amd64,linux/arm64` as build arguments.