### PR TITLE
Add Horizontal Pod Autoscaler (HPA) to VerneMQ Helm chart

### DIFF
--- a/helm/vernemq/templates/horizontalpodautoscaler.yaml
+++ b/helm/vernemq/templates/horizontalpodautoscaler.yaml
@@ -1,4 +1,4 @@
-{{ - if .Values.autoscaling.enabled }}
+{{- if .Values.autoscaling.enabled }}
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -18,24 +18,24 @@ spec:
   metrics:
     {{- if .Values.autoscaling.metrics }}
     {{ toYaml .Values.autoscaling.metrics | nindent 4 }}
-    {{ - end }}
-    {{ - if .Values.autoscaling.cpuAverageUtilization }}
+    {{- end }}
+    {{- if .Values.autoscaling.cpuAverageUtilization }}
     - type: Resource
       resource:
         name: cpu
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.cpuAverageUtilization }}
-    {{ - end }}
-    {{ - if .Values.autoscaling.memAverageUtilization }}
+    {{- end }}
+    {{- if .Values.autoscaling.memAverageUtilization }}
     - type: Resource
       resource:
         name: memory
         target:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.memAverageUtilization }}
-    {{ - end }}
-  {{ - if .Values.autoscaling.behavior }}
+    {{- end }}
+  {{- if .Values.autoscaling.behavior }}
   {{ toYaml .Values.autoscaling.metrics | nindent 2 }}
-  {{ - end }}
-{{ - end }}
+  {{- end }}
+{{- end }}

--- a/helm/vernemq/templates/horizontalpodautoscaler.yaml
+++ b/helm/vernemq/templates/horizontalpodautoscaler.yaml
@@ -1,0 +1,41 @@
+{{ - if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "vernemq.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "vernemq.name" . }}
+    helm.sh/chart: {{ include "vernemq.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "vernemq.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.metrics }}
+    {{ toYaml .Values.autoscaling.metrics | nindent 4 }}
+    {{ - end }}
+    {{ - if .Values.autoscaling.cpuAverageUtilization }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.cpuAverageUtilization }}
+    {{ - end }}
+    {{ - if .Values.autoscaling.memAverageUtilization }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.memAverageUtilization }}
+    {{ - end }}
+  {{ - if .Values.autoscaling.behavior }}
+  {{ toYaml .Values.autoscaling.metrics | nindent 2 }}
+  {{ - end }}
+{{ - end }}

--- a/helm/vernemq/templates/statefulset.yaml
+++ b/helm/vernemq/templates/statefulset.yaml
@@ -16,7 +16,10 @@ metadata:
   {{- end }}
 spec:
   serviceName: {{ include "vernemq.fullname" . }}-headless
+  # Disable replicas configuration if autoscaling is enabled, as HPA will manage the number of replicas
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   podManagementPolicy: {{ .Values.statefulset.podManagementPolicy }}
   updateStrategy:
     type: {{ .Values.statefulset.updateStrategy }}

--- a/helm/vernemq/values.yaml
+++ b/helm/vernemq/values.yaml
@@ -239,6 +239,14 @@ pdb:
   minAvailable: 1
   # maxUnavailable: 1
 
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 10
+  cpuAverageUtilization: 80
+  # memoryAverageUtilization: 80
+  # metrics:
+
 certificates: {}
 
 ## VerneMQ settings


### PR DESCRIPTION
This PR adds Horizontal Pod Autoscaler (HPA) support to the VerneMQ Helm chart to enable dynamic cluster scaling based on resource utilization.

### Key Changes
* `templates/horizontalpodautoscaler.yaml`: Added a new HPA resource using the `autoscaling/v2` API.
* `values.yaml`: Introduced the autoscaling configuration block (CPU/Memory targets, replica bounds, behaviors, and custom metrics). Disabled by default.
* `templates/statefulset.yaml`: Conditionalized the `.spec.replicas` field so it is bypassed when HPA is enabled. This prevents helm upgrade commands from overriding active scaling states.